### PR TITLE
fix(gojira) fix --help|-h

### DIFF
--- a/gojira.sh
+++ b/gojira.sh
@@ -127,8 +127,9 @@ function validate_arguments {
 }
 
 function parse_args {
-  ACTION=$1
-  shift
+  # Do not parse a starting --help|-h as an action
+  # let it fail later. gojira --foo means "no action"
+  ! [[ $1 =~ ^- ]] && ACTION=$1 && shift
 
   while [[ $# -gt 0 ]]; do
     key="$1"
@@ -709,6 +710,9 @@ main() {
   setup
 
   case $ACTION in
+  help)
+    usage
+    ;;
   up)
     # kong path does not exist. This means we are upping a build that came
     # with no auto deps, most probably


### PR DESCRIPTION
Things this PR fixes:
- `gojira help` command did not exist per se. It happened to work since `help` was not an action and it was giving usage. Not that it is documented, but I guess it makes sense to exist too, besides the usual `-h|--help`
- `gojira -h` was not  working properly. It was calling a non existent action `-h` or `--help` and then showed usage, with an error exit code. The fix seemed the simplest way of dealing with it.