### PR TITLE
fix(clone) delete kong dir when cloning an unexisting sha

### DIFF
--- a/gojira.sh
+++ b/gojira.sh
@@ -308,9 +308,9 @@ function create_kong {
       remote="git@github.com:kong"
     fi
     git clone -b ${GOJIRA_TAG} $remote/$GOJIRA_REPO.git $PREFIX || {
-      git clone $remote/$GOJIRA_REPO.git $PREFIX
-      pushd $PREFIX;
-        git checkout $GOJIRA_TAG || exit
+      git clone $remote/$GOJIRA_REPO.git $PREFIX || exit
+      pushd $PREFIX ;
+        git checkout $GOJIRA_TAG || rm -fr "$PWD" && exit
       popd
     }
   popd


### PR DESCRIPTION
If getting a sha (or a wrongly named branch), gojira does the 2 step
clone+checkout.  If the ref trying to be checked out doesn't exist,
the directory should be removed.

CAVEAT: `rm -fr "$PWD"` looks dangerous. Even I can't think how this could be a massive disaster right now, I'm happy to discuss:

- merge this PR 
- closing this PR
- revert #3 
