### PR TITLE
feat(*) expose GOJIRA_EGG env as flag

### DIFF
--- a/gojira.sh
+++ b/gojira.sh
@@ -230,6 +230,10 @@ function parse_args {
         GOJIRA_CLUSTER_INDEX=$2
         shift
         ;;
+      --egg)
+        GOJIRA_EGGS+=("$2")
+        shift
+        ;;
       -)
         _EXTRA_ARGS+=("$(cat $2)")
         _RAW_INPUT=1
@@ -418,6 +422,7 @@ Options:
   --redis-cluster       run redis in cluster mode
   --host                specify hostname for kong container
   --git-https           use https to clone repos
+  --egg                 add a compose egg to make things extra yummy
   -V,  --verbose        echo every command that gets executed
   -h,  --help           display this help
 


### PR DESCRIPTION
Exposes `GOJIRA_EGG` env. through a command flag `--egg` so arbitrary ymls can be added to the final shape. Useful for arbitrary modification of whatever gojira generates.

Ideally, these we could also allow this env to be set pre execution so it always adds the same arbitrary eggs (kind of a config?). If that's useful, we could add that too

### Example

```
# hybrid-ports.yml
version: '3.5'
services:
  kong-cp:
    ports:
      - 8001:8001
  kong-dp:
    ports:
      - 8000:8000
```

`gojira hybrid up --egg hybrid-ports.yml` would expose 8001 and 8000 on kong-cp and kong-dp


```
# all-exposed.yml
version: '3.5'
services:
  kong:
    ports:
      - 8001:8001
      - 8000:8000
  redis:
    ports:
      - 6379:6379
  db:
    ports:
      - 5432:5432
```

`gojira up --egg all-exposed.yml` would up a kong with all relevant (?) ports exposed to their default.