### PR TITLE
feat(gps) add go and kong pluginserver to Docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,22 +67,26 @@ ENV GOPATH=${BUILD_PREFIX}/gopath
 ENV PATH=$GOPATH/bin:${GOROOT}/bin:$PATH
 RUN mkdir -p ${GOROOT} ${GOPATH}
 
-RUN curl -L https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz -o /tmp/go.tar.gz && \
-	tar -xf /tmp/go.tar.gz -C ${GOROOT} --strip-components=1 && \
-    rm /tmp/go.tar.gz
+RUN [ ! -z ${GO_VERSION} ] && ( \
+      curl -L https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz -o /tmp/go.tar.gz && \
+	  tar -xf /tmp/go.tar.gz -C ${GOROOT} --strip-components=1 && \
+      rm /tmp/go.tar.gz ) || \
+    echo "go is not required"
 
 ENV KONG_GO_PLUGINSERVER_INSTALL=${BUILD_PREFIX}/gps
 ENV KONG_GO_PLUGINSERVER=${KONG_GO_PLUGINSERVER}
 
-RUN go version && \
-	mkdir ${KONG_GO_PLUGINSERVER_INSTALL} && \
-    cd ${KONG_GO_PLUGINSERVER_INSTALL} && \
-	go mod init go-pluginserver && \
-	go get -d -v github.com/Kong/go-pluginserver@${KONG_GO_PLUGINSERVER} && \
-	go install -ldflags="-s -w -X main.version=${KONG_GO_PLUGINSERVER}" ... && \
-	cd && \
-    rm -r ${KONG_GO_PLUGINSERVER_INSTALL} && \
-	go-pluginserver --version
+RUN [ ! -z ${KONG_GO_PLUGINSERVER} ] && ( \
+      go version && \
+	  mkdir ${KONG_GO_PLUGINSERVER_INSTALL} && \
+      cd ${KONG_GO_PLUGINSERVER_INSTALL} && \
+	  go mod init go-pluginserver && \
+	  go get -d -v github.com/Kong/go-pluginserver@${KONG_GO_PLUGINSERVER} && \
+	  go install -ldflags="-s -w -X main.version=${KONG_GO_PLUGINSERVER}" ... && \
+	  cd && \
+      rm -r ${KONG_GO_PLUGINSERVER_INSTALL} && \
+	  go-pluginserver --version ) || \
+    echo "Kong go pluginserver is not required"
 
 RUN cpanm --notest Test::Nginx
 RUN cpanm --notest local::lib

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,6 +31,8 @@ ARG OPENSSL
 ARG OPENRESTY
 ARG KONG_NGX_MODULE
 ARG KONG_BUILD_TOOLS
+ARG GO_VERSION
+ARG KONG_GO_PLUGINSERVER
 
 ENV BUILD_PREFIX=/build
 ENV OPENSSL_INSTALL=${BUILD_PREFIX}/openssl
@@ -57,6 +59,30 @@ RUN apt-get update && \
         iputils-ping \
         cpanminus \
         iproute2
+
+# Go and go-pluginserver
+ENV GO_VERSION=${GO_VERSION}
+ENV GOROOT=${BUILD_PREFIX}/go
+ENV GOPATH=${BUILD_PREFIX}/gopath
+ENV PATH=$GOPATH/bin:${GOROOT}/bin:$PATH
+RUN mkdir -p ${GOROOT} ${GOPATH}
+
+RUN curl -L https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz -o /tmp/go.tar.gz && \
+	tar -xf /tmp/go.tar.gz -C ${GOROOT} --strip-components=1 && \
+    rm /tmp/go.tar.gz
+
+ENV KONG_GO_PLUGINSERVER_INSTALL=${BUILD_PREFIX}/gps
+ENV KONG_GO_PLUGINSERVER=${KONG_GO_PLUGINSERVER}
+
+RUN go version && \
+	mkdir ${KONG_GO_PLUGINSERVER_INSTALL} && \
+    cd ${KONG_GO_PLUGINSERVER_INSTALL} && \
+	go mod init go-pluginserver && \
+	go get -d -v github.com/Kong/go-pluginserver@${KONG_GO_PLUGINSERVER} && \
+	go install -ldflags="-s -w -X main.version=${KONG_GO_PLUGINSERVER}" ... && \
+	cd && \
+    rm -r ${KONG_GO_PLUGINSERVER_INSTALL} && \
+	go-pluginserver --version
 
 RUN cpanm --notest Test::Nginx
 RUN cpanm --notest local::lib

--- a/gojira.sh
+++ b/gojira.sh
@@ -504,6 +504,7 @@ function image_name {
     OPENSSL=${OPENSSL:-$(req_find $req_file RESTY_OPENSSL_VERSION)}
     KONG_NGX_MODULE=${KONG_NGX_MODULE:-$(req_find $req_file KONG_NGINX_MODULE_BRANCH)}
     KONG_BUILD_TOOLS=${KONG_BUILD_TOOLS_BRANCH:-$(req_find $req_file KONG_BUILD_TOOLS_BRANCH)}
+    KONG_GO_PLUGINSERVER=${KONG_GO_PLUGINSERVER_VERSION:-$(req_find $req_file KONG_GO_PLUGINSERVER_VERSION)}
   fi
 
   if [[ -f $yaml_file ]]; then
@@ -520,6 +521,8 @@ function image_name {
 
   KONG_NGX_MODULE=${KONG_NGX_MODULE:-master}
   KONG_BUILD_TOOLS=${KONG_BUILD_TOOLS:-master}
+  GO_VERSION=${GO_VERSION:-1.13.12}
+  KONG_GO_PLUGINSERVER=${KONG_GO_PLUGINSERVER:-master}
 
   local components=(
     "luarocks-$LUAROCKS"
@@ -527,6 +530,8 @@ function image_name {
     "openssl-$OPENSSL"
     "knm-$KONG_NGX_MODULE"
     "kbt-$KONG_BUILD_TOOLS"
+    "go-$GO_VERSION"
+    "gps-$KONG_GO_PLUGINSERVER"
   )
 
   GOJIRA_IMAGE=gojira:$(IFS="-" ; echo "${components[*]}")
@@ -542,6 +547,8 @@ function build {
     "--build-arg OPENRESTY=$OPENRESTY"
     "--build-arg KONG_NGX_MODULE=$KONG_NGX_MODULE"
     "--build-arg KONG_BUILD_TOOLS=$KONG_BUILD_TOOLS"
+    "--build-arg GO_VERSION=$GO_VERSION"
+    "--build-arg KONG_GO_PLUGINSERVER=$KONG_GO_PLUGINSERVER"
   )
 
   >&2 echo "Building $GOJIRA_IMAGE"
@@ -551,7 +558,10 @@ function build {
   >&2 echo " * OpenSSL:     $OPENSSL  "
   >&2 echo " * OpenResty:   $OPENRESTY"
   >&2 echo " * LuaRocks:    $LUAROCKS "
+  >&2 echo " * Kong NM:     $KONG_NGX_MODULE"
   >&2 echo " * Kong BT:     $KONG_BUILD_TOOLS"
+  >&2 echo " * Go:          $GO_VERSION"
+  >&2 echo " * Kong GPS:    $KONG_GO_PLUGINSERVER"
   >&2 echo "=========================="
   >&2 echo ""
 

--- a/gojira.sh
+++ b/gojira.sh
@@ -521,8 +521,6 @@ function image_name {
 
   KONG_NGX_MODULE=${KONG_NGX_MODULE:-master}
   KONG_BUILD_TOOLS=${KONG_BUILD_TOOLS:-master}
-  GO_VERSION=${GO_VERSION:-1.13.12}
-  KONG_GO_PLUGINSERVER=${KONG_GO_PLUGINSERVER:-master}
 
   local components=(
     "luarocks-$LUAROCKS"
@@ -530,9 +528,14 @@ function image_name {
     "openssl-$OPENSSL"
     "knm-$KONG_NGX_MODULE"
     "kbt-$KONG_BUILD_TOOLS"
-    "go-$GO_VERSION"
-    "gps-$KONG_GO_PLUGINSERVER"
   )
+  if [[ ! -z $KONG_GO_PLUGINSERVER ]]; then
+    GO_VERSION=${GO_VERSION:-1.13.12}
+    components+=(
+      "go-$GO_VERSION"
+      "gps-$KONG_GO_PLUGINSERVER"
+    )
+  fi
 
   GOJIRA_IMAGE=gojira:$(IFS="-" ; echo "${components[*]}")
 }
@@ -547,8 +550,6 @@ function build {
     "--build-arg OPENRESTY=$OPENRESTY"
     "--build-arg KONG_NGX_MODULE=$KONG_NGX_MODULE"
     "--build-arg KONG_BUILD_TOOLS=$KONG_BUILD_TOOLS"
-    "--build-arg GO_VERSION=$GO_VERSION"
-    "--build-arg KONG_GO_PLUGINSERVER=$KONG_GO_PLUGINSERVER"
   )
 
   >&2 echo "Building $GOJIRA_IMAGE"
@@ -560,8 +561,14 @@ function build {
   >&2 echo " * LuaRocks:    $LUAROCKS "
   >&2 echo " * Kong NM:     $KONG_NGX_MODULE"
   >&2 echo " * Kong BT:     $KONG_BUILD_TOOLS"
-  >&2 echo " * Go:          $GO_VERSION"
-  >&2 echo " * Kong GPS:    $KONG_GO_PLUGINSERVER"
+  if [[ ! -z $KONG_GO_PLUGINSERVER ]]; then
+    BUILD_ARGS+=(
+      "--build-arg GO_VERSION=$GO_VERSION"
+      "--build-arg KONG_GO_PLUGINSERVER=$KONG_GO_PLUGINSERVER"
+    )
+    >&2 echo " * Go:          $GO_VERSION"
+    >&2 echo " * Kong GPS:    $KONG_GO_PLUGINSERVER"
+  fi
   >&2 echo "=========================="
   >&2 echo ""
 


### PR DESCRIPTION
When trying to use Gojira with the latest Kong v2.2.1 release (or `master`), `grpcurl` fails to build when executing `gojira up`:

```sh
Makefile:128: *** "error building grpcurl: no go compiler found in PATH".  Stop.
```

This PR addresses that issue by installing `golang` iff Kong go-pluginserver version is available in the `.requirements` file for the Kong version requested when executing `gojira up`.