### PR TITLE
allow gojira shell to accept --env bindings

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -121,7 +121,25 @@ We can also get a shell into them
 $ gojira shell -t 1.2.0
 [kong-1.2.0:/kong]# exit
 $ gojira shell
-[kong-master:/kong]#
+[kong-master:/kong]# exit
+```
+
+We can pass Environment variable bindings into the kong container.
+The variables can be in the form `KEY=VAL`:
+
+```
+$ gojira shell --env FIZZ=buzz
+[kong-master:/kong]# echo $FIZZ
+buzz
+[kong-master:/kong]# exit
+```
+
+Or simply just `KEY`, assuming that `KEY` is already bound to a value in the calling environment:
+
+```
+$ gojira run@db --env GITHUB_TOKEN -t master printenv | grep GITHUB_TOKEN
+GITHUB_TOKEN=secret
+$
 ```
 
 All gojira instances share a folder between them: `$HOME`. Try it:

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -124,22 +124,17 @@ $ gojira shell
 [kong-master:/kong]# exit
 ```
 
-We can pass Environment variable bindings into the kong container.
-The variables can be in the form `KEY=VAL`:
+We can pass Environment variable bindings into the any of the containers. The variables can be in
+the form `KEY=VAL` or can be referenced simply by name, assuming that `KEY` is already bound to a
+value in the calling environment.
 
 ```
-$ gojira shell --env FIZZ=buzz
+$ gojira shell --env FIZZ=buzz --env GITHUB_TOKEN
 [kong-master:/kong]# echo $FIZZ
 buzz
+[kong-master:/kong]# echo $GITHUB_TOKEN
+secret
 [kong-master:/kong]# exit
-```
-
-Or simply just `KEY`, assuming that `KEY` is already bound to a value in the calling environment:
-
-```
-$ gojira run@db --env GITHUB_TOKEN -t master printenv | grep GITHUB_TOKEN
-GITHUB_TOKEN=secret
-$
 ```
 
 All gojira instances share a folder between them: `$HOME`. Try it:

--- a/gojira.sh
+++ b/gojira.sh
@@ -822,12 +822,12 @@ main() {
     p_compose down -v
     ;;
   shell)
-    run_command $GOJIRA_TARGET $GOJIRA_CLUSTER_INDEX gosh -l -i
+    run_command "$GOJIRA_TARGET" "$GOJIRA_CLUSTER_INDEX" "gosh -l -i"
     ;;
   shell@*)
     # remove shell@, anchored at the start
     local where=${ACTION/#shell@/}
-    run_command $where $GOJIRA_CLUSTER_INDEX sh -l -i
+    run_command "$where" "$GOJIRA_CLUSTER_INDEX" "sh -l -i"
     ;;
   build)
     build


### PR DESCRIPTION
```
[jmiller@euclid Kong]$ export ONE=one
[jmiller@euclid Kong]$ gojira shell --env ONE=$ONE --env TWO=two --env THREE=three -t master
[102a4363f069 kong]# echo "$ONE $TWO $THREE"
one two three
[102a4363f069 kong]# exit
```

Signed-off-by: Jeremy J. Miller <jeremy.miller@konghq.com>