### PR TITLE
Adding simple clarification to --image usage

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -321,7 +321,7 @@ gojira run -t 1.3.0.2 kong start
 ### Using kong release images with gojira
 
 ```bash
-# or set it with --image argument
+# or set it with --image argument on all gojira commands
 export GOJIRA_IMAGE=kong:1.5.0-alpine
 gojira up
 gojira shell


### PR DESCRIPTION
Now that I have read the docs more and see the pattern, this seems
obvious. But when I was stuck trying to gojira an image I was able to
successfully start I did not understand that I needed to specify
`--image` on all the commands.

Signed-off-by: Tyler Ball <tyler.ball@konghq.com>