### PR TITLE
fix(doc) minor correction to getting psql prompt

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -397,7 +397,7 @@ gojira down
 
 gojira up
 gojira run kong roar
-gojira run psql -U kong -h db
+gojira run@db psql -U kong
 ```
 
 #### Snapshot levels


### PR DESCRIPTION
I ran into this minor issue with the docs when searching for `psql`:

```
$ gojira run psql -U kong
sh: 1: psql: not found
$
```

When run as shown below, the user gets a prompt as expected:

```
$ gojira run@db psql -U kong
psql (9.5.24)
Type "help" for help.

kong=#
```

Signed-off-by: Jeremy J. Miller <jeremy.miller@konghq.com>