### PR TITLE
feat(egg) use FIFO files instead of tmp files

### DIFF
--- a/gojira.sh
+++ b/gojira.sh
@@ -616,8 +616,8 @@ function p_compose {
     # Have not found an alternative to this that does not involve a potential
     # dangerous eval
     if executable $egg; then
-      tfile=$(mktemp /tmp/gojira-egg.yml.XXXXXXXXX)
-      $egg > $tfile
+      tfile=$(mktemp -u) && mkfifo "$tfile" || err "[!] Could not create FIFO"
+      $egg > $tfile &
       tmps+=("$tfile")
       flags+=("-f $tfile")
     else


### PR DESCRIPTION
ideally it would be cool to use file descriptors or coprocesses for
these, but it's tricky.

this is an incremental improvement over raw tmp files