### PR TITLE
fix(*) clean up db / --alone handling

### DIFF
--- a/docker/docker-compose.yml.sh
+++ b/docker/docker-compose.yml.sh
@@ -58,11 +58,13 @@ cat << EOF
 EOF
 done
 
-if [[ -n $GOJIRA_DATABASE ]]; then
-  cat << EOF
+
+
+if [[ -n $GOJIRA_DATABASE ]] || [[ -n $GOJIRA_REDIS ]]; then
+cat << EOF
     depends_on:
-      - db
-      - redis
+      $([[ -n $GOJIRA_DATABASE ]] && echo "- db")
+      $([[ -n $GOJIRA_REDIS ]] && echo "- redis")
 EOF
 fi
 
@@ -192,7 +194,7 @@ EOF
   fi
 fi
 
-if [[ -n $GOJIRA_DATABASE ]]; then # --alone means alone
+if [[ -n $GOJIRA_REDIS ]]; then
 cat << EOF
   redis:
     image: redis:5.0.4-alpine

--- a/extra/gojira-hybrid
+++ b/extra/gojira-hybrid
@@ -4,12 +4,7 @@ HYBRID_PATH=$GOJIRA_PATH/extra/hybrid
 GOJIRA_TARGET=kong-cp
 
 kong_cp() {
-  # Ensure there is no database requested
-  if [[ -z $GOJIRA_DATABASE ]]; then
-    CP_DATABASE_ARGS=--alone
-  fi
-
-  GOJIRA_TARGET=kong-cp $0 lay --host kong-cp $CP_DATABASE_ARGS
+  GOJIRA_TARGET=kong-cp $0 lay --host kong-cp
 }
 
 kong_dp() {
@@ -48,7 +43,11 @@ EOF
 hybrid_setup() {
   COMPOSE_FILE=$HYBRID_PATH/docker-compose.yml.sh
 
+  # Propagate setting flags
   export GOJIRA_DATABASE
+  export KONG_DATABASE
+  export GOJIRA_REDIS
+
   export GOJIRA_KONG_PATH
 
   if [[ ! -d "$GOJIRA_KONG_PATH" ]]; then create_kong; fi

--- a/gojira.sh
+++ b/gojira.sh
@@ -31,7 +31,9 @@ globals() {
 # Defaults and overloading
 GOJIRA_KONGS=${GOJIRA_KONGS:-~/.gojira/kongs}
 GOJIRA_HOME=${GOJIRA_HOME:-~/.gojira/home}
-GOJIRA_DATABASE=${GOJIRA_DATABASE:-postgres}
+# only set GOJIRA_DATABASE if it's explicitly not set (empty means empty)
+[[ -z ${GOJIRA_DATABASE+x} ]] && GOJIRA_DATABASE=${GOJIRA_DATABASE:-postgres}
+[[ -z ${GOJIRA_REDIS+x} ]] && GOJIRA_REDIS=${GOJIRA_REDIS:-1}
 GOJIRA_REPO=${GOJIRA_REPO:-kong}
 GOJIRA_TAG=${GOJIRA_TAG:-master}
 GOJIRA_GIT_HTTPS=${GOJIRA_GIT_HTTPS:-0}
@@ -209,8 +211,13 @@ function parse_args {
         GOJIRA_DATABASE=${GOJIRA_DATABASE:+cassandra}
         KONG_DATABASE=cassandra
         ;;
+      --off)
+        GOJIRA_DATABASE=
+        KONG_DATABASE=off
+        ;;
       --alone)
         GOJIRA_DATABASE=
+        GOJIRA_REDIS=
         ;;
       --redis-cluster)
         GOJIRA_REDIS_MODE="cluster"


### PR DESCRIPTION
GOJIRA_DATABASE env has been confusing since the very start, together with the `--alone` flag. It made it more confusing once declarative mode landed and we had a third state "off".

This PR tries to make everything as explicit as possible:
* To get a kong with off strategy, `gojira ... --off` -> no database, KONG_DATABASE=off. Has no effect on redis altogether
* To get just a kong node, no redis, no db, with no side effects on KONG_DATABASE, --alone flag
* Get just a kong node, but also without redis `gojira ... --off --alone`
* On hybrid, the control plane comes with whatever flag settings where passed, and the data plane comes with --off and --alone. It brings up a redis, unless `--alone` is explicitly set.

Any of these can be controled by using envs:
* GOJIRA_DATABASE
* KONG_DATABASE
* GOJIRA_REDIS

@mikefero It all makes sense to me, but maybe it has unintended side effects. Do you sense any possible side effect?
