### PR TITLE
feat(plugin): add postgres read-only replica plugin

### DIFF
--- a/plugins/gojira-postgresro
+++ b/plugins/gojira-postgresro
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+POSTGRES_RO_PATH=$(dirname ${BASH_SOURCE[0]})/postgresro
+
+#  Add commands to usage
+function gojira-postgresro-commands {
+  cat << EOF
+[postgresro] Commands:
+  up                       gojira's up command is annotated
+
+EOF
+}
+
+function gojira-postgresro-usage {
+  cat << EOF
+
+This plugin adds a read-only replica in addition to the primary postgres database.
+
+EOF
+}
+
+replica_egg() {
+  cat << EOF
+version: '3.5'
+services:
+  # add some PG_RO_HOST and point it to the replica
+  ${GOJIRA_TARGET:-kong}:
+    environment:
+      KONG_PG_RO_HOST: postgresro
+
+  # set replica parameters on the db container
+  db:
+    environment:
+      PG_REP_USER: ${KONG_PG_REP_USER:-kongreplica}
+      PG_REP_PASSWORD: 123456
+    # overwrite the entrypoint
+    volumes:
+    - ${POSTGRES_RO_PATH}/pg-entrypoint/primary:/docker-entrypoint-initdb.d:rw
+  # Add new readonly replica postgres instance
+  postgresro:
+    image: postgres
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_USER: ${KONG_PG_USER:-kong}
+      PG_REP_USER:  ${KONG_PG_REP_USER:-kongreplica}
+      PG_REP_PASSWORD: 123456
+    healthcheck:
+      interval: 5s
+      retries: 10
+      test:
+      - CMD
+      - pg_isready
+      - -U
+      - ${KONG_PG_USER:-kong}
+      timeout: 10s
+    image: postgres:latest
+    labels:
+      com.konghq.gojira: "True"
+    networks:
+      gojira: {}
+    ports:
+    - target: 5432
+    restart: on-failure
+    stdin_open: true
+    tty: true
+    volumes:
+    - ${POSTGRES_RO_PATH}/pg-entrypoint/replica:/docker-entrypoint-initdb.d:rw
+EOF
+
+}
+
+postgresro-init() {
+  # include compose file modifications
+  # by using a function
+  GOJIRA_EGGS+=("replica_egg")
+
+  # transform an existing gojira action
+  case $ACTION in
+    up)
+      inf "[postgresro] Adding a read-only replica postgres database"
+      ;;
+  esac
+
+  # This only runs on "mode", not in plugin mode. Thus, makes it the plugin
+  # action call
+  case $1 in
+    help)
+      gojira-postgresro-usage
+      ;;
+  esac
+}
+
+postgresro-init "$@"

--- a/plugins/postgresro/pg-entrypoint/primary/00-setup-primary.sh
+++ b/plugins/postgresro/pg-entrypoint/primary/00-setup-primary.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+pg_conf_file=$PGDATA/postgresql.conf
+
+echo "\
+log_statement = 'all'
+log_disconnections = off
+log_duration = on
+log_min_duration_statement = -1
+shared_preload_libraries = 'pg_stat_statements'
+track_activity_query_size = 2048
+pg_stat_statements.track = all
+pg_stat_statements.max = 10000
+wal_level = hot_standby
+archive_mode = on
+archive_command = 'cd .'
+max_wal_senders = 8
+hot_standby = on
+" >>$pg_conf_file
+
+for database in $(echo $POSTGRES_DBS | tr ',' ' '); do
+  echo "Creating database $database"
+  psql -U $POSTGRES_USER <<-EOSQL
+    CREATE DATABASE $database;
+    GRANT ALL PRIVILEGES ON DATABASE $database TO $POSTGRES_USER;
+    ALTER SYSTEM SET listen_addresses TO '*';
+    CREATE USER $PG_REP_USER REPLICATION LOGIN CONNECTION LIMIT 100 ENCRYPTED PASSWORD '$PG_REP_PASSWORD';
+EOSQL
+done
+
+echo "host replication $PG_REP_USER all md5" >> $PGDATA/pg_hba.conf
+echo "host replication all all md5" >> $PGDATA/pg_hba.conf

--- a/plugins/postgresro/pg-entrypoint/replica/00-setup-ro.sh
+++ b/plugins/postgresro/pg-entrypoint/replica/00-setup-ro.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+/etc/init.d/postgresql stop
+
+rm -rf "${PGDATA:?}/"*
+
+cat > ~/.pgpass.conf <<EOF
+*:5432:replication:${PG_REP_USER}:${PG_REP_PASSWORD}
+EOF
+chmod 0600 ~/.pgpass.conf
+
+until PGPASSFILE=~/.pgpass.conf pg_basebackup -h db -U "$PG_REP_USER" -p 5432 -D "$PGDATA" -Fp -Xs -P -R
+do
+    # If docker is starting the containers simultaneously, the backup may encounter
+    # the primary amidst a restart. Retry until we can make contact.
+    sleep 1
+    echo "Retrying backup . . ."
+done
+chown -R postgres:postgres "$PGDATA"
+
+/etc/init.d/postgresql start


### PR DESCRIPTION
This plugin sets up a read-only replica for postgres

If enabled, the primary config will be adapted as well
as a second postgres created and configured.

Kong is automatically provided with the necessary configs

enable with

`GOJIRA_PLUGINS=postgresro gojira ...`