### PR TITLE
feat(hybrid) allow port mappings in hybrid mode

### DIFF
--- a/extra/hybrid/docker-compose.yml.sh
+++ b/extra/hybrid/docker-compose.yml.sh
@@ -18,6 +18,17 @@ cat << EOF
 EOF
 done
 
+if [[ -n $GOJIRA_PORTS ]]; then
+  cat << EOF
+    ports:
+EOF
+  for port in $GOJIRA_PORTS; do
+    cat << EOF
+        - $port
+EOF
+  done
+fi
+
 cat << EOF
   kong-dp:
     environment:


### PR DESCRIPTION
This adds port mapping support from $GOJIRA_PORTS (-pp/--port) to hybrid mode.

e.g., this will now map control plane ports to the host in hybrid mode:
```
gojira hybrid up \
  -pp 8000:8000 \
  -pp 8001:8001 \
  -pp 8002:8002 \
  -pp 8003:8003 \
  -pp 8004:8004 \
  -pp 8443:8443 \
  -pp 8444:8444 \
  -pp 8445:8445
```