### PR TITLE
Add --yml flag and watch command

### DIFF
--- a/docker/docker-compose.yml.sh
+++ b/docker/docker-compose.yml.sh
@@ -69,6 +69,14 @@ cat << EOF
 EOF
 fi
 
+
+if [[ -n $GOJIRA_KONG_PATH ]]; then
+  cat << EOF
+    working_dir: "${KONG_PATH:-/kong}"
+EOF
+fi
+
+
 cat << EOF
     environment:
       KONG_ROLE: traditional

--- a/docker/docker-compose.yml.sh
+++ b/docker/docker-compose.yml.sh
@@ -41,6 +41,7 @@ cat << EOF
       - ${GOJIRA_HOME}/:/root/
       - ${DOCKER_CTX}/follow-log.sh:/bin/follow-kong-log
       - ${DOCKER_CTX}/gosh.sh:/bin/gosh:ro
+      - ${DOCKER_CTX}/kong-att.sh:/bin/kong-att:ro
       # Inject env vars, since images might not have them
       - ${DOCKER_CTX}/42-kong-envs.sh:/etc/profile.d/42-kong-envs.sh
 EOF

--- a/docker/kong-att.sh
+++ b/docker/kong-att.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+hash nginx 2> /dev/null && ngx='nginx'
+ngx=${ngx:-"/usr/local/openresty/nginx/sbin/nginx"}
+
+export KONG_NGINX_DAEMON=off
+kong prepare -p "$KONG_PREFIX" "$@"
+
+ln -sf /dev/stdout "$KONG_PREFIX/logs/access.log"
+ln -sf /dev/stdout "$KONG_PREFIX/logs/admin_access.log"
+ln -sf /dev/stderr "$KONG_PREFIX/logs/error.log"
+
+exec $ngx -p "$KONG_PREFIX" -c nginx.conf

--- a/extra/gojira-watch
+++ b/extra/gojira-watch
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+GOJIRA_TTY=0
+
+gojira_watch() {
+  local cmd
+
+  if hash fswatch &> /dev/null; then
+    cmd="fswatch -x --event=Updated -o $(eval echo $1)"
+  elif hash inotifywait &> /dev/null; then
+    cmd="inotifywait -m $(eval echo $1) -q -e modify --exclude '*'"
+  else
+    warn "[!] install 'fswatch' (OS X) or inotify-tools for watching"
+    return 1
+  fi
+
+  inf "[-] watching $1 for changes"
+
+  shift
+
+  $cmd | while read -r; do
+    inf "[+] $*"
+    run_command $GOJIRA_TARGET $GOJIRA_CLUSTER_INDEX "$@"
+  done
+}
+
+gojira_watch "$@"

--- a/extra/gojira-yml
+++ b/extra/gojira-yml
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+GOJIRA_YML_FILE=${GOJIRA_YML_FILE}
+
+gojira-yml-usage() {
+  cat << EOF
+
+The very useful 'yml' plugin. Use this plugin to start kong on dbless mode
+using a declarative config file. It will start kong right away and show proxy
+and admin logs on STDIN.
+
+'gojira up --yml path/to/declarative.yml'
+
+'gojira up --yml <(something_that_outputs_a_yml)'
+
+By default, it starts attached. Ctrl-C to stop the container.
+
+Start it dettached by running: 'gojira up --yml declarative.yml -d'
+
+EOF
+}
+
+gojira-yml-egg() {
+cat << EOF
+version: '3.5'
+services:
+  ${GOJIRA_TARGET:-kong}:
+    command: kong-att
+    environment:
+      KONG_DECLARATIVE_CONFIG: "/tmp/gojira_kong.yml"
+      KONG_DATABASE: "off"
+      KONG_ADMIN_ACCESS_LOG: /dev/stdout
+      KONG_ADMIN_ERROR_LOG: /dev/stderr
+      KONG_PROXY_ACCESS_LOG: /dev/stdout
+      KONG_PROXY_ERROR_LOG: /dev/stderr
+    volumes:
+      - $1:/tmp/gojira_kong.yml
+EOF
+}
+
+gojira-yml-add() {
+  [[ -n $1 ]] || err "[!] please provide a yml argument"
+
+  GOJIRA_DATABASE=""
+  unset GOJIRA_DETACH_UP
+
+  local file
+  # It's a file
+  if [[ -f $1 ]]; then
+    file=$1
+    add_egg "gojira-yml-egg $1"
+  elif [[ -r $1 ]]; then
+    file=$(mktemp "/tmp/gojira-yml.XXX")
+    cat $1 > $file
+  else
+    err "[!] '$1' is not a file"
+  fi
+
+  add_egg "gojira-yml-egg $file"
+  GOJIRA_YML_FILE=$file
+}
+
+gojira-yml-setup() {
+  case $1 in
+    help)
+      gojira-yml-usage
+      ;;
+  esac
+
+  # very ugly hack to grok arguments out from global args
+  set -- ${EXTRA_ARGS}
+  local params=()
+
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      --yml)
+        GOJIRA_YML_FILE=$(realpath $2)
+        shift
+        ;;
+      *)
+        params+=("$1")
+        ;;
+    esac
+    shift
+  done
+
+  EXTRA_ARGS="${params[@]}"
+
+  if [[ -n $GOJIRA_YML_FILE ]]; then
+    gojira-yml-add $GOJIRA_YML_FILE
+  fi
+
+}
+
+gojira-yml-setup "$@"

--- a/gojira.sh
+++ b/gojira.sh
@@ -871,6 +871,10 @@ load_plugins() {
         warn "[plugins] gojira-$plugin not found" && continue
       source "gojira-$plugin" "plugin"
     done
+
+    # XXX hack for  default plugins idk
+    source "gojira-yml" "plugin"
+
     # Make sure we do not source them again ( XXX? )
     export _GOJIRA_PLUGINS_LOADED=1
   fi

--- a/gojira.sh
+++ b/gojira.sh
@@ -41,6 +41,7 @@ GOJIRA_GIT_HTTPS=${GOJIRA_GIT_HTTPS:-0}
 GOJIRA_GIT_HTTPS_REMOTE=${GOJIRA_GIT_HTTPS_REMOTE:-:-https://github.com/kong}
 GOJIRA_REDIS_MODE=""
 GOJIRA_CLUSTER_INDEX=${GOJIRA_CLUSTER_INDEX:-1}
+GOJIRA_DETACH_UP=${GOJIRA_DETACH_UP:-"--detach"}
 # Run gojira in "dev" mode or in "image" mode
 GOJIRA_MODE=${GOJIRA_MODE:-dev}
 GOJIRA_NETWORK_MODE=${GOJIRA_NETWORK_MODE}
@@ -459,6 +460,7 @@ Options:
   --git-https           use https to clone repos
   --egg                 add a compose egg to make things extra yummy
   --network-mode        set docker network mode
+  --yml FILE            kong yml file
   -V,  --verbose        echo every command that gets executed
   -h,  --help           display this help
 
@@ -905,7 +907,7 @@ main() {
              "compatible base, but remember to run 'make dev'!"
     fi
 
-    p_compose up -d $EXTRA_ARGS || exit 1
+    p_compose up $GOJIRA_DETACH_UP $EXTRA_ARGS || exit 1
 
     if [[ $GOJIRA_MAGIC_DEV == 1 ]]; then
       magic_dev

--- a/gojira.sh
+++ b/gojira.sh
@@ -493,6 +493,11 @@ Commands:
                          'gojira port@kong:3 8000'
                          'gojira port@redis 6379'
 
+  watch         watch a file or a pattern for changes and run an action on the
+                target container
+                example: 'gojira watch kong.yml "kong reload"'
+                         'gojira watch "* **/**/*"  "kong reload"'
+
   cd            cd into a kong prefix repo
 
   image         show current gojira image


### PR DESCRIPTION
This PR adds some nifty features to gojira. Gotchas, testing and docs are up for grabs 😉 🚀 

## --yml flag

Using this flag gojira will up a kong container, in attached mode, with a kong declarative file configuration. 

```yml
# kong.yml
_format_version: "1.1"

services:
- name: my-service
  url: https://example.com
  plugins:
  - name: key-auth
  routes:
  - name: my-route
    paths:
    - /

consumers:
- username: my-user
  keyauth_credentials:
  - key: my-key
```

```bash
$ export GOJIRA_IMAGE=kong:latest
$ gojira up --yml kong.yml
[+] Running 3/2
 ⠿ Network kong-latest_gojira     Created                                                                                                                                                                      0.0s
 ⠿ Container kong-latest-redis-1  Created                                                                                                                                                                      0.1s
 ⠿ Container kong-latest-kong-1   Created                                                                                                                                                                      0.1s
Attaching to kong-latest-kong-1, kong-latest-redis-1
kong-latest-redis-1  | 1:C 17 Nov 2021 14:35:07.164 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
kong-latest-redis-1  | 1:C 17 Nov 2021 14:35:07.164 # Redis version=5.0.4, bits=64, commit=00000000, modified=0, pid=1, just started
kong-latest-redis-1  | 1:C 17 Nov 2021 14:35:07.164 # Warning: no config file specified, using the default config. In order to specify a config file use redis-server /path/to/redis.conf
kong-latest-redis-1  | 1:M 17 Nov 2021 14:35:07.166 * Running mode=standalone, port=6379.
kong-latest-redis-1  | 1:M 17 Nov 2021 14:35:07.167 # Server initialized
kong-latest-redis-1  | 1:M 17 Nov 2021 14:35:07.167 # WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo never > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled.
kong-latest-redis-1  | 1:M 17 Nov 2021 14:35:07.167 * Ready to accept connections
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 1#0: using the "epoll" event method
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 1#0: openresty/1.19.9.1
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 1#0: built by gcc 10.3.1 20210424 (Alpine 10.3.1_git20210424)
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 1#0: OS: Linux 5.10.47-linuxkit
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 1#0: getrlimit(RLIMIT_NOFILE): 1048576:1048576
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 1#0: start worker processes
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 1#0: start worker process 23
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 1#0: start worker process 24
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 1#0: start worker process 25
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 1#0: start worker process 26
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 1#0: start worker process 27
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 1#0: start worker process 28
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 25#0: *3 [lua] init.lua:260: purge(): [DB cache] purging (local) cache, context: init_worker_by_lua*
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 25#0: *3 [lua] init.lua:260: purge(): [DB cache] purging (local) cache, context: init_worker_by_lua*
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 23#0: *1 [lua] globalpatches.lua:62: sleep(): executing a blocking 'sleep' (0.001 seconds), context: init_worker_by_lua*
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 23#0: *1 [lua] globalpatches.lua:62: sleep(): executing a blocking 'sleep' (0.002 seconds), context: init_worker_by_lua*
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 24#0: *2 [lua] globalpatches.lua:62: sleep(): executing a blocking 'sleep' (0.001 seconds), context: init_worker_by_lua*
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 24#0: *2 [lua] globalpatches.lua:62: sleep(): executing a blocking 'sleep' (0.002 seconds), context: init_worker_by_lua*
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 23#0: *1 [lua] globalpatches.lua:62: sleep(): executing a blocking 'sleep' (0.004 seconds), context: init_worker_by_lua*
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 27#0: *4 [lua] globalpatches.lua:62: sleep(): executing a blocking 'sleep' (0.001 seconds), context: init_worker_by_lua*
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 24#0: *2 [lua] globalpatches.lua:62: sleep(): executing a blocking 'sleep' (0.004 seconds), context: init_worker_by_lua*
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 25#0: *3 [kong] init.lua:394 declarative config loaded from /tmp/gojira_kong.yml, context: init_worker_by_lua*
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 25#0: *3 [kong] init.lua:291 only worker #0 can manage, context: init_worker_by_lua*
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 27#0: *4 [kong] init.lua:291 only worker #0 can manage, context: init_worker_by_lua*
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 24#0: *2 [kong] init.lua:291 only worker #0 can manage, context: init_worker_by_lua*
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 28#0: *6 [kong] init.lua:291 only worker #0 can manage, context: init_worker_by_lua*
kong-latest-kong-1   | 2021/11/17 14:35:10 [notice] 26#0: *5 [kong] init.lua:291 only worker #0 can manage, context: init_worker_by_lua*
```

It starts in attached mode by default, since it seems useful! Can be run detached by passing a `-d | --detach` flag.

### gotchas

* added it as a plugin that is always sourced for users to avoid going the extra mile and add it to `GOJIRA_PLUGINS`.
* removing a `--flag` from the parsed arguments was meh. I had some bigger changes that tried to solve that, but these touched a very big surface area and did not really improve readability.

## watch command

Super useful `watch` command, that runs a command within the target container on change. Mostly untested with anything that is not `fswatch`. Use it like:

```bash
$ gojira watch kong.yml "kong reload"
$ gojira watch "* **/**/*" "kong reload"
```

Even more useful together with the `--yml` flag, but can be used for any command within the container.

### gotchas

* glob star parsing is meh
* having to quote the command is meh