### PR TITLE
feat(cli) add --apt-mirror flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Spin up as many Kong instances as you want. On different commits at the same
 time. With different OpenSSL, OpenResty and LuaRocks versions. Run a shell
 inside of the containers, make Kong roar. Make Kong fail, cd into the repo, fix
 it. Make Kong start again. Commit it. Push it, ship it!
+
 ## Synopsis
 
 ```
@@ -50,6 +51,8 @@ Options:
   --git-https           use https to clone repos
   --egg                 add a compose egg to make things extra yummy
   --network-mode        set docker network mode
+  --yml FILE            kong yml file
+  --apt-mirror DOMAIN   use customized Ubuntu apt mirror (such as --apt-mirror apt-mirror.example.com)
   -V,  --verbose        echo every command that gets executed
   -h,  --help           display this help
 
@@ -82,6 +85,11 @@ Commands:
                          'gojira port@kong:3 8000'
                          'gojira port@redis 6379'
 
+  watch         watch a file or a pattern for changes and run an action on the
+                target container
+                example: 'gojira watch kong.yml "kong reload"'
+                         'gojira watch "* **/**/*"  "kong reload"'
+
   cd            cd into a kong prefix repo
 
   image         show current gojira image
@@ -105,7 +113,6 @@ Commands:
   nuke [-f]     remove all running gojiras. -f for removing all files
 
   version       make a guess
-
 ```
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,13 @@ FROM ubuntu:bionic
 
 ENV DEBIAN_FRONTEND noninteractive
 
+ARG APT_MIRROR=none
+
+RUN if [ ${APT_MIRROR} != none ] ; then \
+        sed -i s/ports.ubuntu.com/${APT_MIRROR}/ /etc/apt/sources.list ; \
+        apt-get clean all ; \
+    fi
+
 # Build tools
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/gojira.sh
+++ b/gojira.sh
@@ -46,6 +46,7 @@ GOJIRA_DETACH_UP=${GOJIRA_DETACH_UP:-"--detach"}
 GOJIRA_MODE=${GOJIRA_MODE:-dev}
 GOJIRA_NETWORK_MODE=${GOJIRA_NETWORK_MODE}
 GOJIRA_TARGET=${GOJIRA_TARGET:-kong}
+GOJIRA_APT_MIRROR=${GOJIRA_APT_MIRROR:-"none"}
 
 # Feature flags. Use the new cool stuff by default. Set it off to the ancient
 # one if it does not work for you
@@ -259,6 +260,10 @@ function parse_args {
         GOJIRA_NETWORK_MODE=$2
         shift
         ;;
+      --apt-mirror)
+        GOJIRA_APT_MIRROR=$2
+        shift
+        ;;
       -)
         _EXTRA_ARGS+=("$(cat $2)")
         _RAW_INPUT=1
@@ -460,6 +465,7 @@ Options:
   --egg                 add a compose egg to make things extra yummy
   --network-mode        set docker network mode
   --yml FILE            kong yml file
+  --apt-mirror DOMAIN   use customized Ubuntu apt mirror (such as --apt-mirror apt-mirror.example.com)
   -V,  --verbose        echo every command that gets executed
   -h,  --help           display this help
 
@@ -624,6 +630,7 @@ function build {
     "--label KONG_NGX_MODULE=$KONG_NGX_MODULE"
     "--build-arg KONG_BUILD_TOOLS=$KONG_BUILD_TOOLS"
     "--label KONG_BUILD_TOOLS=$KONG_BUILD_TOOLS"
+    "--build-arg APT_MIRROR=$GOJIRA_APT_MIRROR"
   )
 
   >&2 echo "Building $GOJIRA_IMAGE"


### PR DESCRIPTION
Somtimes, the default apt mirror is  unstable in some areas. So, users should be allowed to choose their own mirrors.

Usage:

```shell
gojira up -pp 8000:8000 -pp 8001:8001 --apt-mirror apt-mirror.example.com
```