### PR TITLE
fix(cli) can't set `network_mode` to `host`

### DIFF
--- a/extra/hybrid/docker-compose.yml.sh
+++ b/extra/hybrid/docker-compose.yml.sh
@@ -18,15 +18,17 @@ cat << EOF
 EOF
 done
 
-if [[ -n $GOJIRA_PORTS ]]; then
-  cat << EOF
-    ports:
-EOF
-  for port in $GOJIRA_PORTS; do
+if [ "$GOJIRA_NETWORK_MODE" != "host" ]; then
+  if [[ -n $GOJIRA_PORTS ]]; then
     cat << EOF
-        - $port
-EOF
-  done
+      ports:
+  EOF
+    for port in $GOJIRA_PORTS; do
+      cat << EOF
+          - $port
+  EOF
+    done
+  fi
 fi
 
 cat << EOF

--- a/plugins/gojira-kafka
+++ b/plugins/gojira-kafka
@@ -53,12 +53,20 @@ services:
     hostname: broker
     depends_on:
       - zookeeper
+EOF
+
+if [ "$GOJIRA_NETWORK_MODE" != "host" ]; then
+    cat << EOF
     ports:
       - "29092:29092"
       - "19093:19093"
       - "9092:9092"
       - "9093:9093"
       - "9101:9101"
+EOF
+fi
+
+cat << EOF
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
@@ -121,8 +129,16 @@ services:
     image: confluentinc/cp-kafka-rest:${GOJIRA_KAFKA_VERSION:-6.2.0}
     depends_on:
       - broker
+EOF
+
+if [ "$GOJIRA_NETWORK_MODE" != "host" ]; then
+    cat << EOF
     ports:
       - 8082:8082
+EOF
+fi
+
+cat << EOF
     hostname: rest-proxy
     healthcheck:
       test: ["CMD", "curl" ,"http://0.0.0.0:8082/topics"]


### PR DESCRIPTION
If you use Gojira with flag `--network-mode host`, or set environment variable `GOJIRA_NETWORK_MODE` to `host`, you will get a error shown below.

```
ERROR: for kong-xxxx_redis_1  "host" network_mode is incompatible with port_bindings

ERROR: for kong-xxxx_db_1  "host" network_mode is incompatible with port_bindings

ERROR: for redis  "host" network_mode is incompatible with port_bindings

ERROR: for db  "host" network_mode is incompatible with port_bindings

docker.errors.InvalidArgument: "host" network_mode is incompatible with port_bindings
```
