### PR TITLE
fix(gojira-ee) addressed bash orphan processes issue

### DIFF
--- a/gojira.sh
+++ b/gojira.sh
@@ -701,6 +701,14 @@ function executable {
 }
 
 
+function cleanup {
+  local pids=`jobs -p`
+  if [[ "$pids" != "" ]]; then
+    kill $pids
+  fi
+}
+
+
 function p_compose {
   local res
   get_envs
@@ -1038,3 +1046,4 @@ pushd() { builtin pushd $1 > /dev/null; }
 popd() { builtin popd > /dev/null; }
 
 main "$@"
+cleanup   # make sure we clean up


### PR DESCRIPTION
Gojira Enterprise will call back to this project. And yield a bunch of bash orphan processes([ISSUE-17](https://github.com/Kong/gojira-enterprise/issues/17)). After some further poking, it seems to be related to `mkfifo`. I can't quite explain the details of it, but it works.

Ref: https://unix.stackexchange.com/questions/495859/how-to-avoid-zombie-process-while-working-with-named-pipe