### PR TITLE
chore(hybrid) remove unnecessary git clone operation

### DIFF
--- a/extra/gojira-hybrid
+++ b/extra/gojira-hybrid
@@ -72,10 +72,6 @@ hybrid_setup() {
   export KONG_DATABASE
   export GOJIRA_REDIS
 
-  export GOJIRA_KONG_PATH
-
-  if [[ ! -d "$GOJIRA_KONG_PATH" ]]; then create_kong; fi
-
   local actions=()
   while [[ $# -gt 0 ]]; do
     if [[ ! $1 =~ ^- ]]; then


### PR DESCRIPTION
An unnecessary clone action will be triggered if the specified tag doesn't exist while bringing down the docker-compose thingie running in `-t` tag, which is obviously a bit of a waste of time.

e.g.

```sh
$ gojira hybrid down -t 9.7.0
Cloning into '/root/.gojira/kongs/kong-9.7.0'...
fatal: Remote branch 9.7.0 not found in upstream origin
Cloning into '/root/.gojira/kongs/kong-9.7.0'...
remote: Enumerating objects: 75583, done.
remote: Counting objects: 100% (857/857), done.
remote: Compressing objects: 100% (528/528), done.
remote: Total 75583 (delta 436), reused 687 (delta 313), pack-reused 74726
Receiving objects: 100% (75583/75583), 23.04 MiB | 493.00 KiB/s, done.
Resolving deltas: 100% (51192/51192), done.
error: pathspec '9.7.0' did not match any file(s) known to git
[!] could not clone git@github.com:kong/kong.git (9.7.0)
$ 
```