### PR TITLE
enclose boolean values in quotes

### DIFF
--- a/docker/docker-compose.yml.sh
+++ b/docker/docker-compose.yml.sh
@@ -11,7 +11,7 @@ services:
     user: root
     command: "follow-kong-log"
     labels:
-      com.konghq.gojira: True
+      com.konghq.gojira: "True"
     # Add net admin capabilities to containers to allow manipulating traffic
     # control settings (like adding network latency)
     cap_add:
@@ -154,7 +154,7 @@ if [[ -n $GOJIRA_DATABASE ]]; then
 cat << EOF
   db:
     labels:
-      com.konghq.gojira: True
+      com.konghq.gojira: "True"
 EOF
 
   if [[ $GOJIRA_DATABASE == "postgres" ]]; then
@@ -246,7 +246,7 @@ EOF
   cat << EOF
     restart: on-failure
     labels:
-      com.konghq.gojira: True
+      com.konghq.gojira: "True"
 EOF
 
   if [[ $GOJIRA_REDIS_MODE == "cluster" ]]; then


### PR DESCRIPTION
when using gojira with docker-compose v2, some error occured:

> ERROR: The Compose file '/dev/fd/63' is invalid because:
> services.db.labels.com.konghq.gojira contains true, which is an invalid type, it should be a string, number, or a null
> services.kong.labels.com.konghq.gojira contains true, which is an invalid type, it should be a string, number, or a null
> services.redis.labels.com.konghq.gojira contains true, which is an invalid type, it should be a string, number, or a null

The boolean values in docker-compose.yml.sh could be enclosed in quotes, which is compatible in both docker-compose v1 and v2.