### PR TITLE
fix(script): use BASH_SOURCE to identify the correct executable

### DIFF
--- a/gojira.sh
+++ b/gojira.sh
@@ -2,8 +2,8 @@
 
 # Copyright 2019-2022 Kong Inc.
 
-GOJIRA=$(basename $0)
-GOJIRA_PATH=$(dirname $(realpath $0))
+GOJIRA=$(basename ${BASH_SOURCE[0]:-$0})
+GOJIRA_PATH=$(dirname $(realpath ${BASH_SOURCE[0]:-$0}))
 DOCKER_PATH=$GOJIRA_PATH/docker
 DOCKER_FILE=$DOCKER_PATH/Dockerfile
 COMPOSE_FILE=$DOCKER_PATH/docker-compose.yml.sh


### PR DESCRIPTION
If gojira is accessed from any path (e.g. through a symlink in `~/.local/bin/gojira`), the parameter `$0` only contains the name `gojira`. Since `realpath` accepts any name by default (unless it uses the `-e` flag), it will compose an invalid path like `/my/current/folder/gojira` (`my/current/folder` being whatever path gojira was executed from).

`BASH_SOURCE` resolves this for me.