### PR TITLE
Add support for --env-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Options:
   -pp, --port           expose a port for a kong container
   -v,  --volume         add a volume to kong container
   -e,  --env KEY=VAL    add environment variable binding to kong container
+  --env-file .env        read a local environment file and bind the variables to the kong container
   --image               image to use for kong
   --cassandra           use cassandra
   --alone               do not spin up any db


### PR DESCRIPTION
When testing features such as Secrets Management you end up with long `gojira` commands like the following:

```
gojira up -k . -e KONG_VAULT_HCV_PROTOCOL=http -e KONG_VAULT_HCV_HOST="host.docker.internal" -e KONG_VAULT_HCV_PORT=8200 -e KONG_VAULT_HCV_MOUNT=kv -e KONG_VAULT_HCV_KV=v2 -e KONG_VAULT_HCV_TOKEN="hvs.mSpn3s2QSfrLMGX9PD2ZkKpd" -e KONG_VAULTS=hcv
```

This PR adds support for `--env-file`, which allows you to specify commonly used environment variables in a separate file that can be loaded with `source` locally, and by gojira.

`--env-file` may be provided multiple times, e.g.:

```bash
gojira up -k . --env-file .env.hcv --env-file .env.opentelemetry
```

```bash
gojira up -k . --env-file .env.opentelemetry
```

```bash
gojira up -k . --env-file .env.opentelemetry --env-file .env.expressions-router
```


This allows you to mix and match the enabled feature set as needed