### PR TITLE
kong-att: Source 42-kong-envs.sh

### DIFF
--- a/docker/kong-att.sh
+++ b/docker/kong-att.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+. /etc/profile.d/42-kong-envs.sh
+
 hash nginx 2> /dev/null && ngx='nginx'
 ngx=${ngx:-"/usr/local/openresty/nginx/sbin/nginx"}
 


### PR DESCRIPTION
So that the `--yml` argument can be used with `--tag` in addition to `--image`. Images created from tags, with Kong built from `make dev`, don't have the `kong` binary on the default `PATH` and other Lua environment variables set for non-interactive shells. This results in the following error:
```
kong-3-0-0-kong-1   | /bin/kong-att: 7: /bin/kong-att: kong: not found
kong-3-0-0-kong-1   | ln: failed to create symbolic link '/kong/servroot/logs/access.log': No such file or directory
kong-3-0-0-kong-1   | ln: failed to create symbolic link '/kong/servroot/logs/admin_access.log': No such file or directory
kong-3-0-0-kong-1   | ln: failed to create symbolic link '/kong/servroot/logs/error.log': No such file or directory
kong-3-0-0-kong-1   | nginx: [alert] could not open error log file: open() "/kong/servroot/logs/error.log" failed (2: No such file or directory)
kong-3-0-0-kong-1   | 2022/12/04 21:58:57 [emerg] 1#0: open() "/kong/servroot/nginx.conf" failed (2: No such file or directory)
kong-3-0-0-kong-1 exited with code 1
```
It can be reproduced with this `kong.yml`:
```
version: '3.5'
services:
  kong:
    ports:
      - 8000:8000
      - 8001:8001
```
And these commands to build a new image:
```
gojira up --tag 3.0.0
gojira run --tag 3.0.0 make dev 
gojira up --tag 3.0.0 --yml kong.yaml
```